### PR TITLE
Wrong laravel-mix-purgecss version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "autoprefixer": "^9.7.6",
         "cross-env": "^7.0",
         "laravel-mix": "^5.0",
-        "laravel-mix-purgecss": "^5.1.0",
+        "laravel-mix-purgecss": "^5.0.0",
         "postcss-import": "^12.0.1",
         "postcss-nested": "^4.2.1",
         "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
Also with the newest update of tailwind, do we need this?

As we can do this:
```
module.exports = {
  purge: [
    './src/**/*.html',
    './src/**/*.vue',
    './src/**/*.jsx',
  ],
  theme: {},
  variants: {},
  plugins: [],
}
```